### PR TITLE
ci: upgrade to node 16 actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,10 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Description

1. CI Builds were failing due to connection issue with CMS API endpoint. I've updated the environment secrets with new Railway endpoint.
2. Secondly, we were getting below warning in actions as they were running Node 12. I've updated the required actions to run on latest versions ([ref](https://github.com/scriptified/scriptified.dev/actions/runs/3350992489)).

<img width="855" alt="image" src="https://user-images.githubusercontent.com/21218732/198825932-b27f43d7-fc69-4733-8327-b2ace1b92979.png">
