### PR TITLE
feat: integrate vercel analytics

### DIFF
--- a/.changeset/tidy-readers-repeat.md
+++ b/.changeset/tidy-readers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+feat: integrate vercel analytics

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@svgr/webpack": "5.4.0",
+    "@vercel/analytics": "0.1.6",
     "autoprefixer": "10.4.0",
     "axios": "0.21.2",
     "glob": "7.1.6",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '../styles/global.css';
+import { Analytics } from '@vercel/analytics/react';
 import { AppProps } from 'next/app';
 import { ThemeProvider } from '../theme/ThemeContext';
 import { LoadingProvider } from '../components/LoadingContext';
@@ -25,6 +26,7 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
     <ThemeProvider>
       <LoadingProvider>
         <Component {...pageProps} />
+        <Analytics />
       </LoadingProvider>
     </ThemeProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,6 +1487,11 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
+"@vercel/analytics@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-0.1.6.tgz#a1ce184168d8f5ec02e35ec954d84ee68ea01f4b"
+  integrity sha512-zNd5pj3iDvq8IMBQHa1YRcIteiw6ZiPB8AsONHd8ieFXlNpLqhXfIYnf4WvTfZ7S1NSJ++mIM14aJnNac/VMXQ==
+
 acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
- Added `vercel/analytics` package for tracking.
- See it's documentation [here](https://vercel.com/docs/concepts/analytics/audiences), integration is straight forward.