### PR TITLE
feat: add utm params in external urls

### DIFF
--- a/components/ArticleItem.tsx
+++ b/components/ArticleItem.tsx
@@ -10,11 +10,11 @@ const ArticleItem = ({ article }: { article: Article }): JSX.Element => {
   const theme = useThemeState();
   const { title, desc, url, authors, tags } = article;
 
-  const urlWithTrackingParams = getUrlWithUtmTrackingParams(url);
+  const articleUrlWithTrackingParams = getUrlWithUtmTrackingParams({ url });
 
   return (
     <div className="mt-0 mx-0 py-4" key={url}>
-      <a href={urlWithTrackingParams} target="_blank" rel="noreferrer">
+      <a href={articleUrlWithTrackingParams} target="_blank" rel="noreferrer">
         <Text size="2xl" as="h4" color={`text-${theme}-600`} additionalStyles="hover:underline">
           {title}
         </Text>

--- a/components/ArticleItem.tsx
+++ b/components/ArticleItem.tsx
@@ -4,14 +4,17 @@ import Tags from './common/Tags';
 import { useThemeState } from '../theme/ThemeContext';
 import Markdown from './Markdown';
 import Authors from './Authors';
+import { getUrlWithUtmTrackingParams } from '../utils';
 
 const ArticleItem = ({ article }: { article: Article }): JSX.Element => {
   const theme = useThemeState();
   const { title, desc, url, authors, tags } = article;
 
+  const urlWithTrackingParams = getUrlWithUtmTrackingParams(url);
+
   return (
     <div className="mt-0 mx-0 py-4" key={url}>
-      <a href={url} target="_blank" rel="noreferrer">
+      <a href={urlWithTrackingParams} target="_blank" rel="noreferrer">
         <Text size="2xl" as="h4" color={`text-${theme}-600`} additionalStyles="hover:underline">
           {title}
         </Text>

--- a/components/Authors.tsx
+++ b/components/Authors.tsx
@@ -1,4 +1,5 @@
 import Author from '../interfaces/author';
+import { getUrlWithUtmTrackingParams } from '../utils';
 import Text from './common/Text';
 
 function Authors({ authors }: { authors: Array<string> | Array<Author> }): JSX.Element {
@@ -19,8 +20,10 @@ function Authors({ authors }: { authors: Array<string> | Array<Author> }): JSX.E
               );
             }
 
+            const urlWithTrackingParams = getUrlWithUtmTrackingParams(author.website);
+
             return (
-              <a href={author.website} target="_blank" rel="noreferrer" key={author.id}>
+              <a href={urlWithTrackingParams} target="_blank" rel="noreferrer" key={author.id}>
                 <Text as="span" additionalStyles="uppercase hover:underline" size="sm" color="text-gray-600">
                   {isLastElement ? author.name : `${author.name}, `}
                 </Text>

--- a/components/Authors.tsx
+++ b/components/Authors.tsx
@@ -20,10 +20,10 @@ function Authors({ authors }: { authors: Array<string> | Array<Author> }): JSX.E
               );
             }
 
-            const urlWithTrackingParams = getUrlWithUtmTrackingParams(author.website);
+            const authorUrlWithTrackingParams = getUrlWithUtmTrackingParams({ url: author.website });
 
             return (
-              <a href={urlWithTrackingParams} target="_blank" rel="noreferrer" key={author.id}>
+              <a href={authorUrlWithTrackingParams} target="_blank" rel="noreferrer" key={author.id}>
                 <Text as="span" additionalStyles="uppercase hover:underline" size="sm" color="text-gray-600">
                   {isLastElement ? author.name : `${author.name}, `}
                 </Text>

--- a/components/Curators.tsx
+++ b/components/Curators.tsx
@@ -74,7 +74,7 @@ function Curators(): JSX.Element {
       <div className="flex justify-evenly items-center flex-col flex-wrap">
         <div className="grid px-0 lg:px-12">
           {curators.map((curator, index) => {
-            const urlWithTrackingParams = getUrlWithUtmTrackingParams(curator.links.website);
+            const curatorUrlWithTrackingParams = getUrlWithUtmTrackingParams({ url: curator.links.website });
 
             return (
               <div className="flex sm:flex-col md:flex-row flex-wrap pb-8" key={index}>
@@ -83,7 +83,7 @@ function Curators(): JSX.Element {
                 >
                   <div className={`bg-${theme}-100 p-1 rounded`}>
                     <a
-                      href={urlWithTrackingParams}
+                      href={curatorUrlWithTrackingParams}
                       target="_blank"
                       rel="noreferrer"
                       className="flex transition duration-700 hover:scale-105"
@@ -105,7 +105,7 @@ function Curators(): JSX.Element {
                 </div>
                 <div className="flex flex-col">
                   <a
-                    href={urlWithTrackingParams}
+                    href={curatorUrlWithTrackingParams}
                     target="_blank"
                     rel="noreferrer"
                     className={`text-${theme}-800 hover:underline`}

--- a/components/Curators.tsx
+++ b/components/Curators.tsx
@@ -4,6 +4,7 @@ import { useThemeState } from '../theme/ThemeContext';
 import SocialLinks from './common/SocialLinks';
 import Text from './common/Text';
 import Markdown from './Markdown';
+import { getUrlWithUtmTrackingParams } from '../utils';
 
 function shuffle(array: unknown[]): unknown[] {
   const shuffledArray = JSON.parse(JSON.stringify(array));
@@ -73,6 +74,8 @@ function Curators(): JSX.Element {
       <div className="flex justify-evenly items-center flex-col flex-wrap">
         <div className="grid px-0 lg:px-12">
           {curators.map((curator, index) => {
+            const urlWithTrackingParams = getUrlWithUtmTrackingParams(curator.links.website);
+
             return (
               <div className="flex sm:flex-col md:flex-row flex-wrap pb-8" key={index}>
                 <div
@@ -80,7 +83,7 @@ function Curators(): JSX.Element {
                 >
                   <div className={`bg-${theme}-100 p-1 rounded`}>
                     <a
-                      href={curator.links.website}
+                      href={urlWithTrackingParams}
                       target="_blank"
                       rel="noreferrer"
                       className="flex transition duration-700 hover:scale-105"
@@ -102,7 +105,7 @@ function Curators(): JSX.Element {
                 </div>
                 <div className="flex flex-col">
                   <a
-                    href={curator.links.website}
+                    href={urlWithTrackingParams}
                     target="_blank"
                     rel="noreferrer"
                     className={`text-${theme}-800 hover:underline`}

--- a/components/GIFItem.tsx
+++ b/components/GIFItem.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import Gif from '../interfaces/gif';
 import { useThemeState } from '../theme/ThemeContext';
-import { getMediaFormat } from '../utils';
+import { getMediaFormat, getUrlWithUtmTrackingParams } from '../utils';
 import Text from './common/Text';
 import Markdown from './Markdown';
 
@@ -22,6 +22,8 @@ const GIFItem = ({ gif }: { gif: Gif }): JSX.Element => {
   const renderMedia = ({ format, source, caption }: RenderMediaProps): JSX.Element => {
     switch (format) {
       case 'mp4':
+        const sourceWithTrackingParams = getUrlWithUtmTrackingParams(source);
+
         return (
           <video
             autoPlay
@@ -34,9 +36,10 @@ const GIFItem = ({ gif }: { gif: Gif }): JSX.Element => {
             title={caption}
             preload="metadata"
           >
-            <source src={source} type="video/mp4" />
+            <source src={sourceWithTrackingParams} type="video/mp4" />
             <p>
-              Your browser doesn&apos;t support HTML5 video. Here is a <a href={source}>link to the video</a> instead.
+              Your browser doesn&apos;t support HTML5 video. Here is a{' '}
+              <a href={sourceWithTrackingParams}>link to the video</a> instead.
             </p>
           </video>
         );

--- a/components/GIFItem.tsx
+++ b/components/GIFItem.tsx
@@ -22,7 +22,7 @@ const GIFItem = ({ gif }: { gif: Gif }): JSX.Element => {
   const renderMedia = ({ format, source, caption }: RenderMediaProps): JSX.Element => {
     switch (format) {
       case 'mp4':
-        const sourceWithTrackingParams = getUrlWithUtmTrackingParams(source);
+        const sourceWithTrackingParams = getUrlWithUtmTrackingParams({ url: source });
 
         return (
           <video

--- a/components/ToolItem.tsx
+++ b/components/ToolItem.tsx
@@ -6,12 +6,12 @@ import { getUrlWithUtmTrackingParams } from '../utils';
 const ToolItem = ({ tool: { title, url, logo, authors, desc, tags } }: { tool: Tool }): JSX.Element => {
   const article = { title, url, desc, authors, tags };
 
-  const urlWithTrackingParams = getUrlWithUtmTrackingParams(url);
+  const toolUrlWithTrackingParams = getUrlWithUtmTrackingParams({ url });
 
   return (
     <div className="flex flex-wrap sm:flex-nowrap flex-row items-center">
       <a
-        href={urlWithTrackingParams}
+        href={toolUrlWithTrackingParams}
         className="w-full mr-8 max-w-[fit-content] my-4 p-1 transition duration-700 hover:scale-105 img-shadow-sm hover:img-shadow-none"
         target="_blank"
         rel="noreferrer"

--- a/components/ToolItem.tsx
+++ b/components/ToolItem.tsx
@@ -1,14 +1,17 @@
 import Image from 'next/image';
 import ArticleItem from './ArticleItem';
 import Tool from '../interfaces/tool';
+import { getUrlWithUtmTrackingParams } from '../utils';
 
 const ToolItem = ({ tool: { title, url, logo, authors, desc, tags } }: { tool: Tool }): JSX.Element => {
   const article = { title, url, desc, authors, tags };
 
+  const urlWithTrackingParams = getUrlWithUtmTrackingParams(url);
+
   return (
     <div className="flex flex-wrap sm:flex-nowrap flex-row items-center">
       <a
-        href={url}
+        href={urlWithTrackingParams}
         className="w-full mr-8 max-w-[fit-content] my-4 p-1 transition duration-700 hover:scale-105 img-shadow-sm hover:img-shadow-none"
         target="_blank"
         rel="noreferrer"

--- a/components/common/SocialShare.tsx
+++ b/components/common/SocialShare.tsx
@@ -24,12 +24,12 @@ interface ShareLinkProps {
 }
 
 export const ShareLink = ({ text, label, url, icon, showText }: ShareLinkProps): JSX.Element => {
-  const urlWithTrackingParams = getUrlWithUtmTrackingParams(url);
+  const shareUrlWithTrackingParams = getUrlWithUtmTrackingParams({ url });
 
   return (
     <a
       aria-label={label}
-      href={urlWithTrackingParams}
+      href={shareUrlWithTrackingParams}
       className="transition duration-500 ease-in-out hover:scale-125"
       target="_blank"
       rel="noreferrer"

--- a/components/common/SocialShare.tsx
+++ b/components/common/SocialShare.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { CopyIcon, CheckSqaureIcon, TwitterIcon, ShareIcon, WhatsAppIcon, FacebookIcon } from '../icons/icons';
 import { useThemeState } from '../../theme/ThemeContext';
+import { getUrlWithUtmTrackingParams } from '../../utils';
 
 interface SocialShareProps {
   url?: string;
@@ -23,10 +24,12 @@ interface ShareLinkProps {
 }
 
 export const ShareLink = ({ text, label, url, icon, showText }: ShareLinkProps): JSX.Element => {
+  const urlWithTrackingParams = getUrlWithUtmTrackingParams(url);
+
   return (
     <a
       aria-label={label}
-      href={url}
+      href={urlWithTrackingParams}
       className="transition duration-500 ease-in-out hover:scale-125"
       target="_blank"
       rel="noreferrer"

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -54,3 +54,31 @@ export const getMediaFormat = (mediaUrl: string): string => {
       return mediaFormat;
   }
 };
+
+/* =================================================================== */
+
+/**
+ * Get URL with UTM tracking params
+ * @param url URL to be appended with UTM tracking params
+ * @returns {string} URL with UTM tracking params
+ */
+export const getUrlWithUtmTrackingParams = (url: string): string => {
+  const utmParams: Record<string, string> = {
+    utm_source: 'scriptified.dev',
+    utm_medium: 'newsletter',
+  };
+
+  try {
+    const urlWithParams = new URL(url);
+
+    Object.keys(utmParams).forEach(key => {
+      urlWithParams.searchParams.set(key, utmParams[key]);
+    });
+
+    return urlWithParams.toString();
+  } catch (err) {
+    console.error(err);
+    // return url as is if URL is invalid
+    return url;
+  }
+};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -10,7 +10,7 @@
 `wait` milliseconds.
 */
 
-export function debounce<Params extends unknown[]>(
+function debounce<Params extends unknown[]>(
   func: (...args: Params) => unknown,
   timeout: number
 ): (...args: Params) => void {
@@ -25,7 +25,7 @@ export function debounce<Params extends unknown[]>(
 
 /* =================================================================== */
 
-export const convertDate = (date: string): string => {
+const convertDate = (date: string): string => {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
@@ -41,7 +41,7 @@ export const convertDate = (date: string): string => {
  * @param mediaUrl URL of media
  * @returns {string} media format
  */
-export const getMediaFormat = (mediaUrl: string): string => {
+const getMediaFormat = (mediaUrl: string): string => {
   const extension = mediaUrl.split('.');
   const mediaFormat = extension.pop();
 
@@ -57,15 +57,22 @@ export const getMediaFormat = (mediaUrl: string): string => {
 
 /* =================================================================== */
 
+type UtmMedium = 'newsletter' | 'website';
+
+interface UtmParams {
+  utm_source: string;
+  utm_medium: UtmMedium;
+}
+
 /**
  * Get URL with UTM tracking params
  * @param url URL to be appended with UTM tracking params
  * @returns {string} URL with UTM tracking params
  */
-export const getUrlWithUtmTrackingParams = (url: string): string => {
-  const utmParams: Record<string, string> = {
+const getUrlWithUtmTrackingParams = ({ url, medium = 'website' }: { url: string; medium?: UtmMedium }): string => {
+  const utmParams: UtmParams = {
     utm_source: 'scriptified.dev',
-    utm_medium: 'newsletter',
+    utm_medium: medium,
   };
 
   try {
@@ -82,3 +89,5 @@ export const getUrlWithUtmTrackingParams = (url: string): string => {
     return url;
   }
 };
+
+module.exports = { debounce, convertDate, getMediaFormat, getUrlWithUtmTrackingParams };

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -10,7 +10,7 @@
 `wait` milliseconds.
 */
 
-function debounce<Params extends unknown[]>(
+export function debounce<Params extends unknown[]>(
   func: (...args: Params) => unknown,
   timeout: number
 ): (...args: Params) => void {
@@ -25,7 +25,7 @@ function debounce<Params extends unknown[]>(
 
 /* =================================================================== */
 
-const convertDate = (date: string): string => {
+export const convertDate = (date: string): string => {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: 'long',
@@ -41,7 +41,7 @@ const convertDate = (date: string): string => {
  * @param mediaUrl URL of media
  * @returns {string} media format
  */
-const getMediaFormat = (mediaUrl: string): string => {
+export const getMediaFormat = (mediaUrl: string): string => {
   const extension = mediaUrl.split('.');
   const mediaFormat = extension.pop();
 
@@ -69,7 +69,13 @@ interface UtmParams {
  * @param url URL to be appended with UTM tracking params
  * @returns {string} URL with UTM tracking params
  */
-const getUrlWithUtmTrackingParams = ({ url, medium = 'website' }: { url: string; medium?: UtmMedium }): string => {
+export const getUrlWithUtmTrackingParams = ({
+  url,
+  medium = 'website',
+}: {
+  url: string;
+  medium?: UtmMedium;
+}): string => {
   const utmParams: UtmParams = {
     utm_source: 'scriptified.dev',
     utm_medium: medium,
@@ -89,5 +95,3 @@ const getUrlWithUtmTrackingParams = ({ url, medium = 'website' }: { url: string;
     return url;
   }
 };
-
-module.exports = { debounce, convertDate, getMediaFormat, getUrlWithUtmTrackingParams };


### PR DESCRIPTION
## Description

1. Added `getUrlWithUtmTrackingParams` utility function.
2. Copeid same in `issueEmailGenerator.js` node script to utilise it in markdown newsletter emails.

## Testing
1. Deployed on preview, working as expected.
2. For email issue script, generated markdown for issue 17 - worked as expected. sharing output below.

<details><summary>issue17.md</summary>
<p>

```md

![Headshot](https://og.scriptified.dev/Correct%20usage%20of%20the%20useRef%20hook%2C%20understanding%20HTTP%20Cookies%2C%20a%20JavaScript%20game%20engine%20and%20more.png?issue_number=17&date=March%208%2C%202023)

<center>[Read issue on web](https://scriptified.dev/issues/17?utm_source=scriptified.dev&utm_medium=newsletter)</center>

Watch the behind-the-scenes story of React's development, learn how to correctly use the useRef hook, and gain an understanding of how HTTP cookies work. 

# Tip of the day

When you have an array of key-value pairs that you want to convert into an object, you can use `Object.fromEntries` to directly convert them instead of doing it via something like `reduce`. 

 
```js
const entries = [  ['a', 1],
  ['b', 2],
  ['c', 3]
];

// ❌ Instead of doing it like this:
const obj = entries.reduce((acc, [key, value]) => {
  acc[key] = value;
  return acc;
}, {});
// obj = {a: 1, b: 2, c: 3}

// ✅ Use Object.fromEntries instead:
const obj = Object.fromEntries(entries);
// obj = {a: 1, b: 2, c: 3}
```



___

# Articles

[**React useRef Hook for Dummies: How to Use useRef Correctly with Examples**](https://blog.notesnook.com/react-useref-hook-with-examples/?utm_source=scriptified.dev&utm_medium=newsletter)

The article breaks down how to use the React `useRef` hook correctly and explores a few of its different use cases.

*by Ammar Ahmed*

[**A practical, Complete Tutorial on HTTP cookies**](https://www.valentinog.com/blog/cookies/?utm_source=scriptified.dev&utm_medium=newsletter)

Learn how HTTP cookies work: simple, practical examples with JavaScript and Python.

*by Valentino Gagliardi*


___



# Tools

[**melonJS**](https://github.com/melonjs/melonJS?utm_source=scriptified.dev&utm_medium=newsletter)
    
melonJS is a fast and lightweight JavaScript game engine, that just relies on the capabilities of an HTML5-supported browser and has multiple features including WebGL 1 & 2 renderer for desktop and mobile devices with fallback to Canvas rendering, Web Audio support with spatial audio, Mouse and Touch device support etc.

*by melonJS*

[**Color Review**](https://color.review/?utm_source=scriptified.dev&utm_medium=newsletter)
    
A color contrast checker with a visualisation that shows exactly where the WCAG thresholds sit

*by Anton Robsarve*


___

# Tech Talks

[**React.js: The Documentary**](https://youtu.be/8pDqJVdNa44?utm_source=scriptified.dev&utm_medium=newsletter)

https://youtu.be/8pDqJVdNa44?utm_source=scriptified.dev&utm_medium=newsletter)

React.js: The Documentary brings you the full story behind the early days of React, focusing on the dedicated group of developers who helped bring it to the world stage. This story is told by an all-star cast of developers like Tom Occhino, Christopher Chedeau, Pete Hunt, Sebastian Markbåge, Dan Abramov, and many more.

*by Honeypot*

___

# Quiz

### What’s wrong with the following code snippet?

```javascript
function MyComponent() {
  const [count, setCount] = useState(0);

  useEffect(() => {
    const intervalId = setInterval(() => {
      setCount(count + 1);
    }, 1000);
    return () => clearInterval(intervalId);
  }, []);

  return (
    <div>
      <p>Count: {count}</p>
    </div>
  );
}
```

[<div style="margin: 12px 0px; border: 1px solid gray; padding: 16px; background: #F2F3F5;">The `useEffect` hook should not be used with a state update function.</div>](https://scriptified.dev/issues/17?section=quiz&option=1)
[<div style="margin: 12px 0px; border: 1px solid gray; padding: 16px; background: #F2F3F5;">The `setCount` function should take the previous count value as an argument.</div>](https://scriptified.dev/issues/17?section=quiz&option=2)
[<div style="margin: 12px 0px; border: 1px solid gray; padding: 16px; background: #F2F3F5;">The `useEffect` hook is missing a cleanup function to clear the interval.</div>](https://scriptified.dev/issues/17?section=quiz&option=3)
[<div style="margin: 12px 0px; border: 1px solid gray; padding: 16px; background: #F2F3F5;">The `useEffect` hook is missing the `count` variable in the dependency array</div>](https://scriptified.dev/issues/17?section=quiz&option=4)


___

# This week in GIF

![When they ask me to ship to production as soon as possible and without testing (via https://thecodinglove.com/)](https://images.scriptified.dev/issue-17/gif-17.mp4)

[When they ask me to ship to production as soon as possible and without testing (via https://thecodinglove.com/)](https://scriptified.dev/issues/17?section=gif)

---

Liked this issue? [Share on Twitter](https://twitter.com/intent/tweet?text=Have%20a%20look%20at%20issue%20%2317%20of%20Scriptified.%0A%0ASubscribe%20to%20%40scriptified_dev%20for%20more.&url=https%3A%2F%2Fscriptified.dev%2Fissues%2F17%3Futm_source%3Dscriptified.dev%26utm_medium%3Dnewsletter) or [read previous issues](https://scriptified.dev/issues).

```

</p>
</details> 